### PR TITLE
Update form parameters

### DIFF
--- a/src/ConvergeGateway.php
+++ b/src/ConvergeGateway.php
@@ -20,6 +20,8 @@ class ConvergeGateway extends AbstractGateway
             'merchantId' => '',
             'username' => '',
             'password' => '',
+            'ssl_show_form' => true,
+            'ssl_result_format' => 'ASCII',
         );
     }
 
@@ -51,6 +53,26 @@ class ConvergeGateway extends AbstractGateway
     public function setPassword($value)
     {
         return $this->setParameter('password', $value);
+    }
+
+    public function getSslShowForm()
+    {
+        return $this->getParameter('ssl_show_form');
+    }
+
+    public function setSslShowForm($value)
+    {
+        return $this->setParameter('ssl_show_form', $value);
+    }
+
+    public function getSslResultFormat()
+    {
+        return $this->getParameter('ssl_result_format');
+    }
+
+    public function setSslResultFormat($value)
+    {
+        return $this->setParameter('ssl_result_format', $value);
     }
 
     /**

--- a/src/ConvergeGateway.php
+++ b/src/ConvergeGateway.php
@@ -20,7 +20,7 @@ class ConvergeGateway extends AbstractGateway
             'merchantId' => '',
             'username' => '',
             'password' => '',
-            'ssl_show_form' => true,
+            'ssl_show_form' => false,
             'ssl_result_format' => 'ASCII',
         );
     }

--- a/src/Message/ConvergeAbstractRequest.php
+++ b/src/Message/ConvergeAbstractRequest.php
@@ -114,7 +114,7 @@ abstract class ConvergeAbstractRequest extends \Omnipay\Common\Message\AbstractR
             'ssl_user_id' => $this->getUsername(),
             'ssl_pin' => $this->getPassword(),
             'ssl_test_mode' => ($this->getTestMode()) ? 'true' : 'false',
-            'ssl_show_form' => $this->getSslShowForm(),
+            'ssl_show_form' => ($this->getSslShowForm()) ? 'true' : 'false',
             'ssl_result_format' => $this->getSslResultFormat(),
             'ssl_invoice_number' => $this->getSslInvoiceNumber(),
         );

--- a/src/Message/ConvergeAbstractRequest.php
+++ b/src/Message/ConvergeAbstractRequest.php
@@ -114,7 +114,7 @@ abstract class ConvergeAbstractRequest extends \Omnipay\Common\Message\AbstractR
             'ssl_user_id' => $this->getUsername(),
             'ssl_pin' => $this->getPassword(),
             'ssl_test_mode' => ($this->getTestMode()) ? 'true' : 'false',
-            'ssl_show_form' => ($this->getSslShowForm()) ? 'true' : 'false',
+            'ssl_show_form' => ($this->getSslShowForm() && ($this->getSslShowForm() != 'false')) ? 'true' : 'false',
             'ssl_result_format' => $this->getSslResultFormat(),
             'ssl_invoice_number' => $this->getSslInvoiceNumber(),
         );


### PR DESCRIPTION
Changes included:

* Include ssl_show_form and ssl_result_format as gateway parameters so that they can be set at gateway initialisation time.  These parameters are required for all requests.
* The ConvergeAbstractRequest class assumes that ssl_show_form is set to false and ssl_result_format is set to "ASCII", so provide these values as defaults for those parameters.
* ssl_show_form must be provided to the gateway as literal string "true"/"false", not the binary value 1/0 as representing true/false in HTML forms.  Same as the ssl_test_mode parameter.
