### PR TITLE
Add docblocks

### DIFF
--- a/src/ConvergeGateway.php
+++ b/src/ConvergeGateway.php
@@ -1,11 +1,108 @@
-<?php namespace Omnipay\Elavon;
+<?php
+
+namespace Omnipay\Elavon;
 
 use Omnipay\Common\AbstractGateway;
 
 /**
  * Elavon's Converge Gateway
  *
+ * This class processes form post requests using the Elavon/Converge gateway as documented here:
+ * https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
+ *
+ * Also here: https://www.convergepay.com/converge-webapp/developer/#/welcome
+ *
+ * ### Test Mode
+ *
+ * In order to begin testing you will need the following parameters from Elavon/Converge:
+ *
+ * * merchantId, aka ssl_merchant_id
+ * * username, aka ssl_user_id
+ * * password, aka ssl_pin
+ *
+ * These parameters are issued for a short time only.  You need to contact Converge to request an extension
+ * a few days before these parameters expire.
+ *
+ * ### Example
+ *
+ * #### Initialize Gateway
+ *
+ * <code>
+ * //
+ * // Put your gateway credentials here.
+ * //
+ * $credentials = array(
+ *     'merchantId'        => '000000',
+ *     'username'          => 'USERNAME',
+ *     'password'          => 'PASSWORD'
+ *     'testMode'          => true,            // Or false if you want to test production mode
+ * );
+ *
+ * // Create a gateway object
+ * // (routes to GatewayFactory::create)
+ * $gateway = Omnipay::create('Elavon_Converge');
+ *
+ * // Initialise the gateway
+ * $gateway->initialize($credentials);
+ * </code>
+ *
+ * #### Direct Credit Card Payment
+ *
+ * <code>
+ * // Create a credit card object
+ * // The card number doesn't appear to matter in test mode.
+ * $card = new CreditCard(array(
+ *     'firstName'             => 'Example',
+ *     'lastName'              => 'Customer',
+ *     'number'                => '4444333322221111',
+ *     'expiryMonth'           => '01',
+ *     'expiryYear'            => '2020',
+ *     'cvv'                   => '123',
+ *     'billingAddress1'       => '1 Scrubby Creek Road',
+ *     'billingCountry'        => 'AU',
+ *     'billingCity'           => 'Scrubby Creek',
+ *     'billingPostcode'       => '4999',
+ *     'billingState'          => 'QLD',
+ * ));
+ *
+ * // Do a purchase transaction on the gateway
+ * try {
+ *     $transaction = $gateway->purchase(array(
+ *         'amount'        => '10.00',
+ *         'currency'      => 'USD',
+ *         'description'   => 'This is a test purchase transaction.',
+ *         'card'          => $card,
+ *     ));
+ *     $response = $transaction->send();
+ *     $data = $response->getData();
+ *     echo "Gateway purchase response data == " . print_r($data, true) . "\n";
+ *
+ *     if ($response->isSuccessful()) {
+ *         echo "Purchase transaction was successful!\n";
+ *     }
+ * } catch (\Exception $e) {
+ *     echo "Exception caught while attempting authorize.\n";
+ *     echo "Exception type == " . get_class($e) . "\n";
+ *     echo "Message == " . $e->getMessage() . "\n";
+ * }
+ * </code>
+ *
+ * ### Dashboard
+ *
+ * For test payments you should be given a Login URL which will be
+ * https://demo.myvirtualmerchant.com/VirtualMerchantDemo/login.do
+ *
+ * ... and some website credentials.  These will be:
+ *
+ * * Account ID
+ * * User ID
+ * * Password
+ *
+ * The password usually needs to be reset periodically.
+ *
  * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
+ * @see \Omnipay\Elavon\Message\ConvergeAbstractRequest
  */
 class ConvergeGateway extends AbstractGateway
 {
@@ -23,31 +120,64 @@ class ConvergeGateway extends AbstractGateway
         );
     }
 
+    /**
+     * Get the merchant ID
+     *
+     * @return string
+     */
     public function getMerchantId()
     {
         return $this->getParameter('merchantId');
     }
 
+    /**
+     * Set the merchant ID
+     *
+     * @param string $value
+     * @return ConvergeGateway provides a fluent interface
+     */
     public function setMerchantId($value)
     {
         return $this->setParameter('merchantId', $value);
     }
 
+    /**
+     * Get the username
+     *
+     * @return string
+     */
     public function getUsername()
     {
         return $this->getParameter('username');
     }
 
+    /**
+     * Set the username
+     *
+     * @param string $value
+     * @return ConvergeGateway provides a fluent interface
+     */
     public function setUsername($value)
     {
         return $this->setParameter('username', $value);
     }
 
+    /**
+     * Get the password
+     *
+     * @return string
+     */
     public function getPassword()
     {
         return $this->getParameter('password');
     }
 
+    /**
+     * Set the password
+     *
+     * @param string $value
+     * @return ConvergeGateway provides a fluent interface
+     */
     public function setPassword($value)
     {
         return $this->setParameter('password', $value);
@@ -55,7 +185,7 @@ class ConvergeGateway extends AbstractGateway
 
     /**
      * @param array $parameters
-     * @return \Omnipay\Elavon\Message\AuthorizeRequest
+     * @return \Omnipay\Elavon\Message\ConvergeAuthorizeRequest
      */
     public function authorize(array $parameters = array())
     {
@@ -64,7 +194,7 @@ class ConvergeGateway extends AbstractGateway
 
     /**
      * @param array $parameters
-     * @return \Omnipay\Elavon\Message\PurchaseRequest
+     * @return \Omnipay\Elavon\Message\ConvergePurchaseRequest
      */
     public function purchase(array $parameters = array())
     {
@@ -73,7 +203,7 @@ class ConvergeGateway extends AbstractGateway
 
     /**
      * @param array $parameters
-     * @return \Omnipay\Elavon\Message\PurchaseRequest
+     * @return \Omnipay\Elavon\Message\ConvergePurchaseRequest
      */
     public function createCard(array $parameters = array())
     {

--- a/src/Message/ConvergeAbstractRequest.php
+++ b/src/Message/ConvergeAbstractRequest.php
@@ -1,7 +1,112 @@
-<?php namespace Omnipay\Elavon\Message;
+<?php
+
+namespace Omnipay\Elavon\Message;
 
 use Omnipay\Common\CreditCard;
 
+/**
+ * Elavon's Converge Abstract Request
+ *
+ * This class processes form post requests using the Elavon/Converge gateway as documented here:
+ * https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
+ *
+ * Also here: https://www.convergepay.com/converge-webapp/developer/#/welcome
+ *
+ * ### Test Mode
+ *
+ * In order to begin testing you will need the following parameters from Elavon/Converge:
+ *
+ * * merchantId, aka ssl_merchant_id
+ * * username, aka ssl_user_id
+ * * password, aka ssl_pin
+ *
+ * These parameters are issued for a short time only.  You need to contact Converge to request an extension
+ * a few days before these parameters expire.
+ *
+ * ### Example
+ *
+ * #### Initialize Gateway
+ *
+ * <code>
+ * //
+ * // Put your gateway credentials here.
+ * //
+ * $credentials = array(
+ *     'merchantId'        => '000000',
+ *     'username'          => 'USERNAME',
+ *     'password'          => 'PASSWORD'
+ *     'testMode'          => true,            // Or false if you want to test production mode
+ * );
+ *
+ * // Create a gateway object
+ * // (routes to GatewayFactory::create)
+ * $gateway = Omnipay::create('Elavon_Converge');
+ *
+ * // Initialise the gateway
+ * $gateway->initialize($credentials);
+ * </code>
+ *
+ * #### Direct Credit Card Payment
+ *
+ * <code>
+ * // Create a credit card object
+ * // The card number doesn't appear to matter in test mode.
+ * $card = new CreditCard(array(
+ *     'firstName'             => 'Example',
+ *     'lastName'              => 'Customer',
+ *     'number'                => '4444333322221111',
+ *     'expiryMonth'           => '01',
+ *     'expiryYear'            => '2020',
+ *     'cvv'                   => '123',
+ *     'billingAddress1'       => '1 Scrubby Creek Road',
+ *     'billingCountry'        => 'AU',
+ *     'billingCity'           => 'Scrubby Creek',
+ *     'billingPostcode'       => '4999',
+ *     'billingState'          => 'QLD',
+ * ));
+ *
+ * // Do a purchase transaction on the gateway
+ * try {
+ *     $transaction = $gateway->purchase(array(
+ *         'amount'        => '10.00',
+ *         'currency'      => 'USD',
+ *         'description'   => 'This is a test purchase transaction.',
+ *         'card'          => $card,
+ *     ));
+ *     $response = $transaction->send();
+ *     $data = $response->getData();
+ *     echo "Gateway purchase response data == " . print_r($data, true) . "\n";
+ *
+ *     if ($response->isSuccessful()) {
+ *         echo "Purchase transaction was successful!\n";
+ *     }
+ * } catch (\Exception $e) {
+ *     echo "Exception caught while attempting purchase.\n";
+ *     echo "Exception type == " . get_class($e) . "\n";
+ *     echo "Message == " . $e->getMessage() . "\n";
+ * }
+ * </code>
+ *
+ * ### Endpoints
+ *
+ * The production and test endpoints are as shown below in the $testEndpoint and $liveEndpoint
+ * class variables.
+ *
+ * ### Quirks
+ *
+ * Two additional parameters need to be sent with every request.  These should be set to defaults
+ * in the Gateway class but in case they are not, set them to the following values as shown on
+ * every transaction request before calling $transaction->send():
+ *
+ * <code>
+ * $transaction->setSslShowForm('false');
+ * $transaction->setSslResultFormat('ASCII');
+ * </code>
+ *
+ * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
+ * @see \Omnipay\Elavon\ConvergeGateway
+ */
 abstract class ConvergeAbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 {
     protected $testEndpoint = 'https://demo.myvirtualmerchant.com/VirtualMerchantDemo';
@@ -12,91 +117,194 @@ abstract class ConvergeAbstractRequest extends \Omnipay\Common\Message\AbstractR
         return ($this->getTestMode()) ? $this->testEndpoint : $this->liveEndpoint;
     }
 
+    /**
+     * Get the merchant ID
+     *
+     * @return string
+     */
     public function getMerchantId()
     {
         return $this->getParameter('merchantId');
     }
 
+    /**
+     * Set the merchant ID
+     *
+     * @param string $value
+     * @return ConvergeAbstractRequest provides a fluent interface
+     */
     public function setMerchantId($value)
     {
         return $this->setParameter('merchantId', $value);
     }
 
+    /**
+     * Get the username
+     *
+     * @return string
+     */
     public function getUsername()
     {
         return $this->getParameter('username');
     }
 
+    /**
+     * Set the username
+     *
+     * @param string $value
+     * @return ConvergeAbstractRequest provides a fluent interface
+     */
     public function setUsername($value)
     {
         return $this->setParameter('username', $value);
     }
 
+    /**
+     * Get the password
+     *
+     * @return string
+     */
     public function getPassword()
     {
         return $this->getParameter('password');
     }
 
+    /**
+     * Set the password
+     *
+     * @param string $value
+     * @return ConvergeAbstractRequest provides a fluent interface
+     */
     public function setPassword($value)
     {
         return $this->setParameter('password', $value);
     }
 
+    /**
+     * Get the SSL show form parameter
+     *
+     * @return string
+     */
     public function getSslShowForm()
     {
         return $this->getParameter('ssl_show_form');
     }
 
+    /**
+     * Set the SSL show form parameter
+     *
+     * Should default to "true".
+     *
+     * @param string $value
+     * @return ConvergeAbstractRequest provides a fluent interface
+     */
     public function setSslShowForm($value)
     {
         return $this->setParameter('ssl_show_form', $value);
     }
 
+    /**
+     * Get the SSL result format parameter
+     *
+     * @return string
+     */
     public function getSslResultFormat()
     {
         return $this->getParameter('ssl_result_format');
     }
 
+    /**
+     * Set the SSL result format parameter
+     *
+     * Should default to "ASCII".
+     *
+     * @param string $value
+     * @return ConvergeAbstractRequest provides a fluent interface
+     */
     public function setSslResultFormat($value)
     {
         return $this->setParameter('ssl_result_format', $value);
     }
 
+    /**
+     * Get the sales tax parameter
+     *
+     * @return string
+     */
     public function getSslSalesTax()
     {
         return $this->getParameter('ssl_salestax');
     }
 
+    /**
+     * Set the sales tax parameter
+     *
+     * @param string $value
+     * @return ConvergeAbstractRequest provides a fluent interface
+     */
     public function setSslSalesTax($value)
     {
         return $this->setParameter('ssl_salestax', $value);
     }
 
+    /**
+     * Get the invoice number parameter
+     *
+     * @return string
+     */
     public function getSslInvoiceNumber()
     {
         return $this->getParameter('ssl_invoice_number');
     }
 
+    /**
+     * Set the invoice number parameter
+     *
+     * @param string $value
+     * @return ConvergeAbstractRequest provides a fluent interface
+     */
     public function setSslInvoiceNumber($value)
     {
         return $this->setParameter('ssl_invoice_number', $value);
     }
 
+    /**
+     * Get the first name parameter
+     *
+     * @return string
+     */
     public function getSslFirstName()
     {
         return $this->getParameter('ssl_first_name');
     }
 
+    /**
+     * Set the first name parameter
+     *
+     * @param string $value
+     * @return ConvergeAbstractRequest provides a fluent interface
+     */
     public function setSslFirstName($value)
     {
         return $this->setParameter('ssl_first_name', $value);
     }
 
+    /**
+     * Get the last name parameter
+     *
+     * @return string
+     */
     public function getSslLastName()
     {
         return $this->getParameter('ssl_last_name');
     }
 
+    /**
+     * Set the last name parameter
+     *
+     * @param string $value
+     * @return ConvergeAbstractRequest provides a fluent interface
+     */
     public function setSslLastName($value)
     {
         return $this->setParameter('ssl_last_name', $value);
@@ -107,6 +315,9 @@ abstract class ConvergeAbstractRequest extends \Omnipay\Common\Message\AbstractR
         return $this->response = new ConvergeResponse($this, $response);
     }
 
+    /**
+     * @return array
+     */
     protected function getBaseData()
     {
         $data = array(

--- a/src/Message/ConvergeAuthorizeRequest.php
+++ b/src/Message/ConvergeAuthorizeRequest.php
@@ -1,5 +1,109 @@
-<?php namespace Omnipay\Elavon\Message;
+<?php
 
+namespace Omnipay\Elavon\Message;
+
+/**
+ * Elavon's Converge Authorize Request
+ *
+ * This class processes form post requests using the Elavon/Converge gateway as documented here:
+ * https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
+ *
+ * Also here: https://www.convergepay.com/converge-webapp/developer/#/welcome
+ *
+ * ### Test Mode
+ *
+ * In order to begin testing you will need the following parameters from Elavon/Converge:
+ *
+ * * merchantId, aka ssl_merchant_id
+ * * username, aka ssl_user_id
+ * * password, aka ssl_pin
+ *
+ * These parameters are issued for a short time only.  You need to contact Converge to request an extension
+ * a few days before these parameters expire.
+ *
+ * ### Example
+ *
+ * #### Initialize Gateway
+ *
+ * <code>
+ * //
+ * // Put your gateway credentials here.
+ * //
+ * $credentials = array(
+ *     'merchantId'        => '000000',
+ *     'username'          => 'USERNAME',
+ *     'password'          => 'PASSWORD'
+ *     'testMode'          => true,            // Or false if you want to test production mode
+ * );
+ *
+ * // Create a gateway object
+ * // (routes to GatewayFactory::create)
+ * $gateway = Omnipay::create('Elavon_Converge');
+ *
+ * // Initialise the gateway
+ * $gateway->initialize($credentials);
+ * </code>
+ *
+ * #### Direct Credit Card Authorize
+ *
+ * <code>
+ * // Create a credit card object
+ * // The card number doesn't appear to matter in test mode.
+ * $card = new CreditCard(array(
+ *     'firstName'             => 'Example',
+ *     'lastName'              => 'Customer',
+ *     'number'                => '4444333322221111',
+ *     'expiryMonth'           => '01',
+ *     'expiryYear'            => '2020',
+ *     'cvv'                   => '123',
+ *     'billingAddress1'       => '1 Scrubby Creek Road',
+ *     'billingCountry'        => 'AU',
+ *     'billingCity'           => 'Scrubby Creek',
+ *     'billingPostcode'       => '4999',
+ *     'billingState'          => 'QLD',
+ * ));
+ *
+ * // Do an authorize transaction on the gateway
+ * try {
+ *     $transaction = $gateway->authorize(array(
+ *         'amount'        => '10.00',
+ *         'currency'      => 'USD',
+ *         'description'   => 'This is a test purchase transaction.',
+ *         'card'          => $card,
+ *     ));
+ *     $response = $transaction->send();
+ *     $data = $response->getData();
+ *     echo "Gateway authorize response data == " . print_r($data, true) . "\n";
+ *
+ *     if ($response->isSuccessful()) {
+ *         echo "Authorize transaction was successful!\n";
+ *     }
+ * } catch (\Exception $e) {
+ *     echo "Exception caught while attempting authorize.\n";
+ *     echo "Exception type == " . get_class($e) . "\n";
+ *     echo "Message == " . $e->getMessage() . "\n";
+ * }
+ * </code>
+ *
+ * ### Quirks
+ *
+ * Two additional parameters need to be sent with every request.  These should be set to defaults
+ * in the Gateway class but in case they are not, set them to the following values as shown on
+ * every transaction request before calling $transaction->send():
+ *
+ * <code>
+ * $transaction->setSslShowForm('false');
+ * $transaction->setSslResultFormat('ASCII');
+ * </code>
+ *
+ * This gateway supports authorize() but does not support capture() so there is no way to capture
+ * a previous authorization.  I am guessing that the standard procedure is to abandon the previous
+ * authorize and issue a purchase() request in its place.
+ *
+ * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
+ * @see \Omnipay\Elavon\ConvergeGateway
+ */
 class ConvergeAuthorizeRequest extends ConvergeAbstractRequest
 {
     protected $transactionType = 'ccauthonly';

--- a/src/Message/ConvergeGenerateTokenRequest.php
+++ b/src/Message/ConvergeGenerateTokenRequest.php
@@ -1,5 +1,105 @@
-<?php namespace Omnipay\Elavon\Message;
+<?php
 
+namespace Omnipay\Elavon\Message;
+
+/**
+ * Elavon's Converge Generate Token Request
+ *
+ * This class processes form post requests using the Elavon/Converge gateway as documented here:
+ * https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
+ *
+ * Also here: https://www.convergepay.com/converge-webapp/developer/#/welcome
+ *
+ * ### Test Mode
+ *
+ * In order to begin testing you will need the following parameters from Elavon/Converge:
+ *
+ * * merchantId, aka ssl_merchant_id
+ * * username, aka ssl_user_id
+ * * password, aka ssl_pin
+ *
+ * These parameters are issued for a short time only.  You need to contact Converge to request an extension
+ * a few days before these parameters expire.
+ *
+ * ### Example
+ *
+ * #### Initialize Gateway
+ *
+ * <code>
+ * //
+ * // Put your gateway credentials here.
+ * //
+ * $credentials = array(
+ *     'merchantId'        => '000000',
+ *     'username'          => 'USERNAME',
+ *     'password'          => 'PASSWORD'
+ *     'testMode'          => true,            // Or false if you want to test production mode
+ * );
+ *
+ * // Create a gateway object
+ * // (routes to GatewayFactory::create)
+ * $gateway = Omnipay::create('Elavon_Converge');
+ *
+ * // Initialise the gateway
+ * $gateway->initialize($credentials);
+ * </code>
+ *
+ * #### Create Token
+ *
+ * <code>
+ * // Create a credit card object
+ * // The card number doesn't appear to matter in test mode.
+ * $card = new CreditCard(array(
+ *     'firstName'             => 'Example',
+ *     'lastName'              => 'Customer',
+ *     'number'                => '4444333322221111',
+ *     'expiryMonth'           => '01',
+ *     'expiryYear'            => '2020',
+ *     'cvv'                   => '123',
+ *     'billingAddress1'       => '1 Scrubby Creek Road',
+ *     'billingCountry'        => 'AU',
+ *     'billingCity'           => 'Scrubby Creek',
+ *     'billingPostcode'       => '4999',
+ *     'billingState'          => 'QLD',
+ * ));
+ *
+ * // Do a create card transaction on the gateway
+ * try {
+ *     $transaction = $gateway->createCard(array(
+ *         'card'          => $card,
+ *     ));
+ *     $response = $transaction->send();
+ *     $data = $response->getData();
+ *     echo "Gateway authorize response data == " . print_r($data, true) . "\n";
+ *
+ *     if ($response->isSuccessful()) {
+ *         echo "Create Card transaction was successful!\n";
+ *
+ *         $cardToken = $response->getCardReference();
+ *         echo "Create Card reference == $cardToken\n";
+ *     }
+ * } catch (\Exception $e) {
+ *     echo "Exception caught while attempting create card.\n";
+ *     echo "Exception type == " . get_class($e) . "\n";
+ *     echo "Message == " . $e->getMessage() . "\n";
+ * }
+ * </code>
+ *
+ * ### Quirks
+ *
+ * Two additional parameters need to be sent with every request.  These should be set to defaults
+ * in the Gateway class but in case they are not, set them to the following values as shown on
+ * every transaction request before calling $transaction->send():
+ *
+ * <code>
+ * $transaction->setSslShowForm('false');
+ * $transaction->setSslResultFormat('ASCII');
+ * </code>
+ *
+ * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
+ * @see \Omnipay\Elavon\ConvergeGateway
+ */
 class ConvergeGenerateTokenRequest extends ConvergeAbstractRequest
 {
     protected $transactionType = 'ccgettoken';

--- a/src/Message/ConvergePurchaseRequest.php
+++ b/src/Message/ConvergePurchaseRequest.php
@@ -1,5 +1,105 @@
-<?php namespace Omnipay\Elavon\Message;
+<?php
 
+namespace Omnipay\Elavon\Message;
+
+/**
+ * Elavon's Converge Purchase Request
+ *
+ * This class processes form post requests using the Elavon/Converge gateway as documented here:
+ * https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
+ *
+ * Also here: https://www.convergepay.com/converge-webapp/developer/#/welcome
+ *
+ * ### Test Mode
+ *
+ * In order to begin testing you will need the following parameters from Elavon/Converge:
+ *
+ * * merchantId, aka ssl_merchant_id
+ * * username, aka ssl_user_id
+ * * password, aka ssl_pin
+ *
+ * These parameters are issued for a short time only.  You need to contact Converge to request an extension
+ * a few days before these parameters expire.
+ *
+ * ### Example
+ *
+ * #### Initialize Gateway
+ *
+ * <code>
+ * //
+ * // Put your gateway credentials here.
+ * //
+ * $credentials = array(
+ *     'merchantId'        => '000000',
+ *     'username'          => 'USERNAME',
+ *     'password'          => 'PASSWORD'
+ *     'testMode'          => true,            // Or false if you want to test production mode
+ * );
+ *
+ * // Create a gateway object
+ * // (routes to GatewayFactory::create)
+ * $gateway = Omnipay::create('Elavon_Converge');
+ *
+ * // Initialise the gateway
+ * $gateway->initialize($credentials);
+ * </code>
+ *
+ * #### Direct Credit Card Payment
+ *
+ * <code>
+ * // Create a credit card object
+ * // The card number doesn't appear to matter in test mode.
+ * $card = new CreditCard(array(
+ *     'firstName'             => 'Example',
+ *     'lastName'              => 'Customer',
+ *     'number'                => '4444333322221111',
+ *     'expiryMonth'           => '01',
+ *     'expiryYear'            => '2020',
+ *     'cvv'                   => '123',
+ *     'billingAddress1'       => '1 Scrubby Creek Road',
+ *     'billingCountry'        => 'AU',
+ *     'billingCity'           => 'Scrubby Creek',
+ *     'billingPostcode'       => '4999',
+ *     'billingState'          => 'QLD',
+ * ));
+ *
+ * // Do a purchase transaction on the gateway
+ * try {
+ *     $transaction = $gateway->purchase(array(
+ *         'amount'        => '10.00',
+ *         'currency'      => 'USD',
+ *         'description'   => 'This is a test purchase transaction.',
+ *         'card'          => $card,
+ *     ));
+ *     $response = $transaction->send();
+ *     $data = $response->getData();
+ *     echo "Gateway purchase response data == " . print_r($data, true) . "\n";
+ *
+ *     if ($response->isSuccessful()) {
+ *         echo "Purchase transaction was successful!\n";
+ *     }
+ * } catch (\Exception $e) {
+ *     echo "Exception caught while attempting purchase.\n";
+ *     echo "Exception type == " . get_class($e) . "\n";
+ *     echo "Message == " . $e->getMessage() . "\n";
+ * }
+ * </code>
+ *
+ * ### Quirks
+ *
+ * Two additional parameters need to be sent with every request.  These should be set to defaults
+ * in the Gateway class but in case they are not, set them to the following values as shown on
+ * every transaction request before calling $transaction->send():
+ *
+ * <code>
+ * $transaction->setSslShowForm('false');
+ * $transaction->setSslResultFormat('ASCII');
+ * </code>
+ *
+ * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
+ * @see \Omnipay\Elavon\ConvergeGateway
+ */
 class ConvergePurchaseRequest extends ConvergeAuthorizeRequest
 {
     public function getData()

--- a/src/Message/ConvergeResponse.php
+++ b/src/Message/ConvergeResponse.php
@@ -1,4 +1,6 @@
-<?php namespace Omnipay\Elavon\Message;
+<?php
+
+namespace Omnipay\Elavon\Message;
 
 use Omnipay\Common\Message\AbstractResponse;
 use Omnipay\Common\Message\RequestInterface;
@@ -39,8 +41,20 @@ class ConvergeResponse extends AbstractResponse
         return $this->data['ssl_result'];
     }
 
+    /**
+     * Get the credit card token.
+     *
+     * Note that this function should be called as getCardReference() as per omnipay standards.
+     *
+     * @return string
+     */
     public function getCardToken()
     {
         return (isset($this->data['ssl_token'])) ? $this->data['ssl_token'] : null;
+    }
+
+    public function getCardReference()
+    {
+        return $this->getCardToken();
     }
 }

--- a/tests/Message/ConvergeGenerateTokenRequestTest.php
+++ b/tests/Message/ConvergeGenerateTokenRequestTest.php
@@ -21,7 +21,7 @@ class ConvergeGenerateTokenRequestTest extends TestCase
         $this->setMockHttpResponse('ConvergeCreateCardResponse.txt');
         $response = $this->request->send();
         $this->assertTrue($response->isSuccessful());
-        $this->assertSame('7595301425001111', $response->getCardToken());
+        $this->assertSame('7595301425001111', $response->getCardReference());
     }
 
 }


### PR DESCRIPTION
This adds docblocks to the class and adds some examples as per the omnipay standards.

There are no code changes here except for the addition of one function in the ConvergeResponse class, because the standard call to retrieve a card reference is getCardReference not getCardToken.
