### PR TITLE
adding ssl_avs_zip to ccgettoken request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 composer.phar
 phpunit.xml
 /tests/Mock/myCredentials.json
+.idea

--- a/src/ConvergeGateway.php
+++ b/src/ConvergeGateway.php
@@ -90,7 +90,7 @@ use Omnipay\Common\AbstractGateway;
  * ### Dashboard
  *
  * For test payments you should be given a Login URL which will be
- * https://demo.myvirtualmerchant.com/VirtualMerchantDemo/login.do
+ * https://api.demo.convergepay.com/VirtualMerchantDemo/login.do
  *
  * ... and some website credentials.  These will be:
  *
@@ -100,7 +100,7 @@ use Omnipay\Common\AbstractGateway;
  *
  * The password usually needs to be reset periodically.
  *
- * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://api.convergepay.com/VirtualMerchant/
  * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
  * @see \Omnipay\Elavon\Message\ConvergeAbstractRequest
  */

--- a/src/Message/ConvergeAbstractRequest.php
+++ b/src/Message/ConvergeAbstractRequest.php
@@ -103,14 +103,14 @@ use Omnipay\Common\CreditCard;
  * $transaction->setSslResultFormat('ASCII');
  * </code>
  *
- * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://api.convergepay.com/VirtualMerchant/
  * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
  * @see \Omnipay\Elavon\ConvergeGateway
  */
 abstract class ConvergeAbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 {
-    protected $testEndpoint = 'https://demo.myvirtualmerchant.com/VirtualMerchantDemo';
-    protected $liveEndpoint = 'https://www.myvirtualmerchant.com/VirtualMerchant';
+    protected $testEndpoint = 'https://api.demo.convergepay.com/VirtualMerchantDemo';
+    protected $liveEndpoint = 'https://api.convergepay.com/VirtualMerchant';
 
     public function getEndpoint()
     {

--- a/src/Message/ConvergeAuthorizeRequest.php
+++ b/src/Message/ConvergeAuthorizeRequest.php
@@ -96,7 +96,7 @@ namespace Omnipay\Elavon\Message;
  * $transaction->setSslResultFormat('ASCII');
  * </code>
  *
- * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://api.convergepay.com/VirtualMerchant/
  * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
  * @see \Omnipay\Elavon\ConvergeGateway
  */

--- a/src/Message/ConvergeCaptureRequest.php
+++ b/src/Message/ConvergeCaptureRequest.php
@@ -66,7 +66,7 @@ namespace Omnipay\Elavon\Message;
  * }
  * </code>
  *
- * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://api.convergepay.com/VirtualMerchant/
  * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
  * @see \Omnipay\Elavon\ConvergeGateway
  */

--- a/src/Message/ConvergeGenerateTokenRequest.php
+++ b/src/Message/ConvergeGenerateTokenRequest.php
@@ -124,6 +124,7 @@ class ConvergeGenerateTokenRequest extends ConvergeAbstractRequest
             'ssl_address2' => $this->getCard()->getAddress2(),
             'ssl_city' => $this->getCard()->getCity(),
             'ssl_state' => $this->getCard()->getState(),
+            'ssl_avs_zip' => $this->getCard()->getPostcode(),
             'ssl_country' => $this->getCard()->getCountry(),
             'ssl_add_token' => 'Y',
 

--- a/src/Message/ConvergeGenerateTokenRequest.php
+++ b/src/Message/ConvergeGenerateTokenRequest.php
@@ -96,7 +96,7 @@ namespace Omnipay\Elavon\Message;
  * $transaction->setSslResultFormat('ASCII');
  * </code>
  *
- * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://api.convergepay.com/VirtualMerchant/
  * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
  * @see \Omnipay\Elavon\ConvergeGateway
  */

--- a/src/Message/ConvergePurchaseRequest.php
+++ b/src/Message/ConvergePurchaseRequest.php
@@ -96,7 +96,7 @@ namespace Omnipay\Elavon\Message;
  * $transaction->setSslResultFormat('ASCII');
  * </code>
  *
- * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://api.convergepay.com/VirtualMerchant/
  * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
  * @see \Omnipay\Elavon\ConvergeGateway
  */

--- a/src/Message/ConvergeRefundRequest.php
+++ b/src/Message/ConvergeRefundRequest.php
@@ -66,7 +66,7 @@ namespace Omnipay\Elavon\Message;
  * }
  * </code>
  *
- * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://api.convergepay.com/VirtualMerchant/
  * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
  * @see \Omnipay\Elavon\ConvergeGateway
  */

--- a/src/Message/ConvergeVoidRequest.php
+++ b/src/Message/ConvergeVoidRequest.php
@@ -65,7 +65,7 @@ namespace Omnipay\Elavon\Message;
  * }
  * </code>
  *
- * @link https://www.myvirtualmerchant.com/VirtualMerchant/
+ * @link https://api.convergepay.com/VirtualMerchant/
  * @link https://resourcecentre.elavonpaymentgateway.com/index.php/download-developer-guide
  * @see \Omnipay\Elavon\ConvergeGateway
  */

--- a/tests/Message/ConvergeAuthorizeRequestTest.php
+++ b/tests/Message/ConvergeAuthorizeRequestTest.php
@@ -37,13 +37,13 @@ class ConvergeAuthorizeRequestTest extends TestCase
     public function testGetTestEndpoint()
     {
         $this->assertSame($this->request, $this->request->setTestMode(true));
-        $this->assertSame('https://demo.myvirtualmerchant.com/VirtualMerchantDemo', $this->request->getEndpoint());
+        $this->assertSame('https://api.demo.convergepay.com/VirtualMerchantDemo', $this->request->getEndpoint());
     }
 
     public function testGetLiveEndpoint()
     {
         $this->assertSame($this->request, $this->request->setTestMode(false));
-        $this->assertSame('https://www.myvirtualmerchant.com/VirtualMerchant', $this->request->getEndpoint());
+        $this->assertSame('https://api.convergepay.com/VirtualMerchant', $this->request->getEndpoint());
     }
 
     public function testIntegrationTesting()

--- a/tests/Message/ConvergePurchaseRequestTest.php
+++ b/tests/Message/ConvergePurchaseRequestTest.php
@@ -34,13 +34,13 @@ class ConvergePurchaseRequestTest extends TestCase
     public function testGetTestEndpoint()
     {
         $this->assertSame($this->request, $this->request->setTestMode(true));
-        $this->assertSame('https://demo.myvirtualmerchant.com/VirtualMerchantDemo', $this->request->getEndpoint());
+        $this->assertSame('https://api.demo.convergepay.com/VirtualMerchantDemo', $this->request->getEndpoint());
     }
 
     public function testGetLiveEndpoint()
     {
         $this->assertSame($this->request, $this->request->setTestMode(false));
-        $this->assertSame('https://www.myvirtualmerchant.com/VirtualMerchant', $this->request->getEndpoint());
+        $this->assertSame('https://api.convergepay.com/VirtualMerchant', $this->request->getEndpoint());
     }
 
     public function testGetData()


### PR DESCRIPTION
Using the default configuration on an elavon sandbox account I was receiving the following error when attempting to use my generated tokens:

Error: 4009
Message: The field Postal Code (ssl_avs_zip) required but not supplied in the authorization request.

Turns out that ccgettoken includes all of the address fields except the zipcode when tokenizing credit card information. After including the ssl_avs_zip field and generating a new token, the tokenzied payment was accepted.